### PR TITLE
Fix for #13

### DIFF
--- a/src/polynomials/orthpolys.jl
+++ b/src/polynomials/orthpolys.jl
@@ -245,7 +245,7 @@ function TransformedPolys(J, trans, rl, ru)
    # get the combined type if rl, ru are different 
    T = promote_type(typeof(rl), typeof(ru))
    # integer is not allowed and we then default to float64 
-   if T <: Integer 
+   if !(T <: AbstractFloat)
       T = Float64 
    end 
    rl_ = convert(T, rl) 

--- a/src/polynomials/orthpolys.jl
+++ b/src/polynomials/orthpolys.jl
@@ -241,8 +241,17 @@ end
    (J1.rl == J2.rl) &&
    (J1.ru == J2.ru) )
 
-TransformedPolys(J, trans, rl, ru) =
-   TransformedPolys(J, trans, rl, ru)
+function TransformedPolys(J, trans, rl, ru)
+   # get the combined type if rl, ru are different 
+   T = promote_type(typeof(rl), typeof(ru))
+   # integer is not allowed and we then default to float64 
+   if T <: Integer 
+      T = Float64 
+   end 
+   rl_ = convert(T, rl) 
+   ru_ = convert(T, ru)
+   TransformedPolys(J, trans, rl_, ru_)
+end
 
 write_dict(J::TransformedPolys) = Dict(
       "__id__" => "ACE1_TransformedPolys",

--- a/src/polynomials/orthpolys.jl
+++ b/src/polynomials/orthpolys.jl
@@ -250,7 +250,7 @@ function TransformedPolys(J, trans, rl, ru)
    end 
    rl_ = convert(T, rl) 
    ru_ = convert(T, ru)
-   TransformedPolys(J, trans, rl_, ru_)
+   return TransformedPolys(J, trans, rl_, ru_)
 end
 
 write_dict(J::TransformedPolys) = Dict(


### PR DESCRIPTION
This should fix #13 ;  @wcwitt  please let me know if this seems sensible to you: 
* If `rin, rcut` are of a different type, then a promoted type is used
* If the promoted type is not a real float then we default to Float64. 
