### PR TITLE
WIP: `read_potential` convenience wrapper

### DIFF
--- a/src/ACE1.jl
+++ b/src/ACE1.jl
@@ -59,6 +59,7 @@ include("utils/pure.jl")
 
 include("compat/compat.jl")
 
+include("fio.jl")
 
 include("export/export.jl")
 include("export/export_multispecies.jl")

--- a/src/fio.jl
+++ b/src/fio.jl
@@ -1,0 +1,31 @@
+
+
+"""
+`read_potential(fname::AbstractString; format = :auto)` : convenience
+function to load an ACE1 potential. If `format == :auto` it tries to 
+guess the format from the ending of the filename. If this fails, then 
+one can try to pass the format explicitly as a kwarg, 
+* `format = :json` for a raw json file 
+* `format = :zip` for a zipped json file that was written using `JuLIP.FIO.zip_dict`
+"""
+function read_potential(fname::AbstractString; format = :auto)
+   if format == :auto 
+      if fname[end-3:end] == "json"
+         format = :json
+      elseif fname[end-2:end] == "zip"
+         format = :zip
+      else
+         error("Unknown filename ending")
+      end
+   end 
+   
+   if format == :json
+      D = load_dict(fname)
+   elseif format == :zip
+      D = unzip_dict(fname)
+   else
+      error("Unknown filename ending; maybe try to explicitly pass the format")
+      return nothing 
+   end
+   
+end

--- a/src/fio.jl
+++ b/src/fio.jl
@@ -1,22 +1,29 @@
 
 
+export load_potential, save_potential
+
+function _auto_format(fname)
+   if fname[end-3:end] == "json"
+      format = :json
+   elseif fname[end-2:end] == "zip"
+      format = :zip
+   else
+      error("Unknown filename ending; try to pass the format explicitly as a kwarg")
+   end
+   return format 
+end
+
 """
-`read_potential(fname::AbstractString; format = :auto)` : convenience
+`load_potential(fname::AbstractString; format = :auto)` : convenience
 function to load an ACE1 potential. If `format == :auto` it tries to 
 guess the format from the ending of the filename. If this fails, then 
 one can try to pass the format explicitly as a kwarg, 
 * `format = :json` for a raw json file 
 * `format = :zip` for a zipped json file that was written using `JuLIP.FIO.zip_dict`
 """
-function read_potential(fname::AbstractString; format = :auto)
+function load_potential(fname::AbstractString; format = :auto)
    if format == :auto 
-      if fname[end-3:end] == "json"
-         format = :json
-      elseif fname[end-2:end] == "zip"
-         format = :zip
-      else
-         error("Unknown filename ending")
-      end
+      format = _auto_format(fname)
    end 
    
    if format == :json
@@ -24,8 +31,25 @@ function read_potential(fname::AbstractString; format = :auto)
    elseif format == :zip
       D = unzip_dict(fname)
    else
-      error("Unknown filename ending; maybe try to explicitly pass the format")
+      error("Unknown file format")
       return nothing 
    end
    
+   return read_dict(D)
 end
+
+function save_potential(fname::AbstractString, V; format = :auto)
+   if format == :auto 
+      format = _auto_format(fname)
+   end 
+
+   D = write_dict(V)
+   if format == :json 
+      JuLIP.FIO.save_dict(fname, D)
+   elseif format == :zip 
+      JuLIP.FIO.zip_dict(fname, D)
+   else      
+      error("Unknown file format")
+   end
+end
+

--- a/src/fio.jl
+++ b/src/fio.jl
@@ -38,6 +38,14 @@ function load_potential(fname::AbstractString; format = :auto)
    return read_dict(D)
 end
 
+"""
+`save_potential(fname::AbstractString, V; format = :auto)` : convenience
+function to save an ACE1 potential to disk. If `format == :auto` it tries to 
+guess the format from the ending of the filename. If this fails, then 
+one can try to pass the format explicitly as a kwarg, 
+* `format = :json` for a raw json file 
+* `format = :zip` for to write a compressed json file using `JuLIP.FIO.zip_dict`
+"""
 function save_potential(fname::AbstractString, V; format = :auto)
    if format == :auto 
       format = _auto_format(fname)

--- a/test/test_pipot.jl
+++ b/test/test_pipot.jl
@@ -8,7 +8,7 @@
 
 @testset "PIPotential"  begin
 
-#---
+##
 
 
 using ACE1, ACE1.Testing
@@ -16,7 +16,7 @@ using Printf, Test, LinearAlgebra, JuLIP, JuLIP.Testing, Random
 using JuLIP: evaluate, evaluate_d, evaluate_ed
 using ACE1: combine
 
-#---
+##
 
 @info("Basic test of PIPotential construction and evaluation")
 maxdeg = 10
@@ -42,9 +42,26 @@ grad_V = evaluate_d(V, Rs, Zs, z0)
 println_slim(@test(grad_basis ≈ grad_V))
 println_slim(@test(evaluate_d(Vdag, Rs, Zs, z0) ≈ grad_V))
 
-println(@test(all(JuLIP.Testing.test_fio(V))))
 
-#---
+##
+
+@info("Test FIO")
+println_slim(@test(all(JuLIP.Testing.test_fio(V))))
+
+@info("Check FIO with `read_potential`")
+tmpf_json = tempname() * ".json"
+tmpf_zip = tempname() * ".zip"
+
+save_potential(tmpf_json, V)
+V_json = load_potential(tmpf_json)
+println_slim(@test V_json == V)
+
+save_potential(tmpf_zip, V)
+V_zip = load_potential(tmpf_zip)
+println_slim(@test V_zip == V)
+
+
+##
 
 # check multi-species
 maxdeg = 5
@@ -69,7 +86,8 @@ println_slim(@test(evaluate_d(Vdag, Rs, Zs, z0) ≈ grad_V))
 
 println(@test(all(JuLIP.Testing.test_fio(V))))
 
-#---
+
+##
 
 @info("Check several properties of PIPotential")
 for species in (:X, :Si, [:C, :O, :H]), N = 1:5
@@ -122,7 +140,7 @@ for species in (:X, :Si, [:C, :O, :H]), N = 1:5
 end
 println()
 
-#---
+##
 
 
 @info("Check Correctness of ACE1.PIPotential calculators")
@@ -156,6 +174,6 @@ for N = 1:5
 end
 
 
-#---
+##
 
 end


### PR DESCRIPTION
This adresses #12  - It introduces 
- `save_potential` 
- `load_potential`
I used `save, load` instead of `read, write` since I've used that convention to distinguish between writing to a dict and writing to disk. But we can discuss if the naming bothers you.

 @bernstei does this do what you want? 