### PR TITLE
fixing a segfault

### DIFF
--- a/src/polynomials/sphericalharmonics.jl
+++ b/src/polynomials/sphericalharmonics.jl
@@ -47,11 +47,12 @@ spher2cart(S::PseudoSpherical) = S.r * JVec(S.cosφ*S.sinθ, S.sinφ*S.sinθ, S.
 
 function cart2spher(R::AbstractVector)
 	@assert length(R) == 3
-	r = norm(R)
+	r = norm(R) 
+	r_ = r + eps(r)   # this is maybe not good, the code is no longer scale-invariant!!! 
 	φ = atan(R[2], R[1])
 	sinφ, cosφ = sincos(φ)
-	cosθ = R[3] / r
-	sinθ = sqrt(R[1]^2+R[2]^2) / r
+	cosθ = R[3] / r_
+	sinθ = sqrt(R[1]^2+R[2]^2) / r_
 	return PseudoSpherical(r, cosφ, sinφ, cosθ, sinθ)
 end
 

--- a/test/polynomials/test_ylm.jl
+++ b/test/polynomials/test_ylm.jl
@@ -73,7 +73,7 @@ for n = 1:nsamples
    print_tf((@test Y ≈ Yex || norm(Y - Yes, Inf) < 1e-12))
 end
 println()
-##
+## 
 
 verbose=false
 @info("Test: check derivatives of associated legendre polynomials")
@@ -134,6 +134,23 @@ for nsamples = 1:30
    print_tf((@test R ≈ spher2cart(cart2spher(R))))
 end
 println()
+
+
+##
+
+@info("    ... at the pole")
+r = SVector(0.0, 0.0, 0.0)
+s = cart2spher(r)
+println(@test(s.r == 0.0) )
+println(@test(spher2cart(s) == r))
+
+@info("Very large numbers")
+for ntest = 1:20
+   rr = 1e130 * rand(SVector{3, Float64})
+   s = cart2spher(rr)
+   print_tf(@test(abs(s.cosθ) <= 1))
+end
+
 
 ##
 


### PR DESCRIPTION
This is a first step towards fixing the not entirely stable Ylms. Now it they will behave ok when the input = a zero-vector. The second possible segfault occurs when the input is >> 1e100, namely when norm(r) = Inf because squaring takes us outside the range of Float64. Any thoughts on whether we need to think about this too? @casv2 @davkovacs 

(David - you could try this branch to look for more segfaults...)