### PR TITLE
Radial Basis with Envelope

### DIFF
--- a/examples/newreg.jl
+++ b/examples/newreg.jl
@@ -1,0 +1,90 @@
+
+using ACE1, LinearAlgebra, Plots
+using ACE1: evaluate
+
+r0, rcut = 2.7, 5.5 
+trans = AgnesiTransform(r0)
+envelope = ACE1.PolyEnvelope(2, r0, rcut)
+Jold = transformed_jacobi(10, trans, rcut)
+Jnew = transformed_jacobi_env(10, trans, envelope, rcut)
+
+Γ3 = Diagonal((1:length(Jold)).^3)
+Γ0 = Diagonal((1:length(Jold)).^0)
+
+##
+
+"""
+This defines a rdf with a peak at r0 and another peak at 2r0 
+"""
+function r_sample(r0, rcut, σ = 6.0, rin = 0.85*r0)
+   r = -1.0 
+   while r < rin || r > rcut 
+      f = rand([1, 2, 2, 2, 2])
+      r = f * r0 + f * randn() / σ
+   end
+   return r 
+end
+
+# we can see here what this distribution looks like. It is supposed 
+# to mimic a realistic RDF. 
+R = [r_sample(r0, rcut) for i = 1:10_000]
+Plots.histogram(R, nbins=50, yscale = :log10)
+
+
+## 
+# a "proper" training set - we will fit the potential to averages 
+# which corresponds more or less to total energies
+Rs = [ [ r_sample(r0, rcut) for i = 1:rand(20:40) ] for _ = 1:15 ]
+rdf = vcat(Rs...)
+
+
+mean(J, R::AbstractVector{<: Number}) = 
+         sum(evaluate(J, r) for r in R) / length(R)
+
+"""
+A baby lsq fit of a pair potential to mean data. 
+"""
+function lsq_fit(f, Rs, J, Γ)
+   A = zeros(length(Rs), length(J))
+   y = zeros(length(Rs))
+   for i = 1:length(Rs)
+      R = Rs[i]
+      A[i, :] = mean(J, R)
+      y[i] = mean(f, R)
+   end
+   A = [A; Γ]
+   y = [y; zeros(length(J))]
+   θ = qr(A) \ y 
+   return r -> dot(θ, evaluate(J, r))
+end
+
+##
+
+Rs = [ [ r_sample(r0, rcut) for i = 1:rand(20:40) ] for _ = 1:100 ]
+rdf = vcat(Rs...)
+xp = range(0.1, rcut, length=300)
+
+g_target(r) = exp(-10*(r/r0-1)) - 2* exp(-5*(r/r0-1))
+f_target(r) = g_target(r) - g_target(rcut)
+ACE1.evaluate(::typeof(f_target), args...) = f_target(args...)
+
+plot(xp, f_target.(xp),  lw=2, label = "target", legend = :topleft, 
+      ylims=[-1.2, 300.0], )
+
+V_old = lsq_fit(f_target, Rs, Jold, 0.0002*Γ3)
+
+plot!(xp, V_old.(xp), lw=2, label = "old")
+
+V_new = lsq_fit(f_target, Rs, Jnew, 0.0002*Γ3)
+plt = plot!(xp, V_new.(xp), lw=2, label = "new")
+
+plt1 = plot!(deepcopy(plt); ylims=[-1.0, 0.2])
+
+plot(plt, plt1, histogram(rdf, nbins=30, xlims = [0.1, rcut], label = "rdf", legend = :topleft), 
+     layout = grid(3, 1, heights=[0.5, 0.4, 0.1]), 
+     size = (800, 800))
+
+
+
+##
+

--- a/examples/newreg/Project.toml
+++ b/examples/newreg/Project.toml
@@ -1,0 +1,9 @@
+[deps]
+ACE1 = "e3f9bc04-086e-409a-ba78-e9769fe067bb"
+ACE1pack = "8c4e8d19-0bd6-4234-8309-7210652e3178"
+IPFitting = "3002bd4c-79e4-52ce-b924-91256dde4e52"
+JuLIP = "945c410c-986d-556a-acb1-167a618e0462"
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+LowRankApprox = "898213cb-b102-5a47-900c-97e73b919f73"
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"

--- a/examples/newreg/newreg.jl
+++ b/examples/newreg/newreg.jl
@@ -88,3 +88,5 @@ plot(plt, plt1, histogram(rdf, nbins=30, xlims = [0.1, rcut], label = "rdf", leg
 
 ##
 
+using ACE1pack
+tial_set = ACE1pack.artifact("Ti

--- a/examples/newreg/tial.jl
+++ b/examples/newreg/tial.jl
@@ -1,0 +1,335 @@
+using ACE1pack, ACE1, IPFitting, StaticArrays, Plots
+using ACE1: transformed_jacobi, transformed_jacobi_env
+using LinearAlgebra: Diagonal
+
+data_file = joinpath(ACE1pack.artifact("TiAl_tutorial"), "TiAl_tutorial.xyz")
+data = IPFitting.Data.read_xyz(data_file, energy_key="energy", force_key="force", virial_key="virial")
+train = data[1:2:end]
+test = data[2:2:end]
+
+##
+
+species = [:Ti, :Al]
+r0 = 2.88
+rcut = 5.5 
+
+# standard ace basis 
+
+maxdeg = 6 
+trans = AgnesiTransform(r0)
+# envelope = ACE1.TwoSidedEnvelope(trans(rcut), trans(0.66*r0), 2, 2)
+# rbasis = transformed_jacobi_env(maxdeg, trans, envelope, rcut)
+
+ACE_B = ace_basis(species = species,
+                  N = 3,
+                  r0 = r0,
+                  rin = 0.7 * r0,
+                  rcut = rcut,
+                  pcut = 2, pin = 2, 
+                  trans=trans, 
+                  maxdeg = maxdeg);
+
+# radial basis 
+trans_r = AgnesiTransform(r0)
+envelope_r = ACE1.PolyEnvelope(2, r0, rcut)
+Jold = transformed_jacobi(16, trans_r, rcut)
+Jnew = transformed_jacobi_env(16, trans_r, envelope_r, rcut)
+
+Bpair_old = PolyPairBasis(Jold, species)
+Bpair_new = PolyPairBasis(Jnew, species)
+
+Bold = JuLIP.MLIPs.IPSuperBasis([Bpair_old, ACE_B]);
+Bnew = JuLIP.MLIPs.IPSuperBasis([Bpair_new, ACE_B]);
+
+# reference potential (numbers from Cas' tutorial)
+Vref = OneBody(:Ti => -1586.0195, :Al => -105.5954)
+
+# regression weights (numbers from Cas' tutorial)
+weights = Dict(
+        "FLD_TiAl" => Dict("E" => 30.0, "F" => 1.0 , "V" => 1.0 ),
+        "TiAl_T5000" => Dict("E" => 5.0, "F" => 1.0 , "V" => 1.0 ))
+
+##
+
+# solver parameters 
+# solver = Dict("solver" => :rrqr, 
+#               "rrqr_tol" => 1e-6, 
+#               "P" => Γ
+#               )
+# solver = Dict("solver" => :brr, 
+#               "brr_tol" => 1e-3, 
+#               "P" => Γ
+#               )
+# solver= Dict(
+#    "solver" => :ard,
+#    "ard_tol" => 1e-3,
+#    "ard_threshold_lambda" => 10000)
+
+
+## fit both potentials - Parameters for Polytransform 
+if trans isa PolyTransform
+   dB = LsqDB("", Bold, train);
+   # smoothness prior 
+   Γ = Diagonal(vcat(ACE1.scaling.(dB.basis.BB, 3)...))
+
+   solver = Dict("solver" => :rrqr, "rrqr_tol" => 3e-6, "P" => Γ)
+   IP_old, lsqinfo_old = lsqfit(dB, solver=solver, weights=weights, Vref=Vref, error_table = true)
+   IPFitting.add_fits!(IP_old, test)
+   rmse_table(lsqinfo_old["errors"])
+   rmse_table(test)
+
+   dB = LsqDB("", Bnew, train);
+   solver = Dict("solver" => :rrqr, "rrqr_tol" => 3e-6, "P" => Γ)
+   IP_new, lsqinfo_new = lsqfit(dB, solver=solver, weights=weights, Vref=Vref, error_table = true)
+   IPFitting.add_fits!(IP_new, test)
+   rmse_table(lsqinfo_new["errors"])
+   rmse_table(test)
+
+elseif trans isa AgnesiTransform
+   # fit both potentials - Parameters for AgnesiTransform
+
+   dB = LsqDB("", Bold, train);
+   Γ = Diagonal(vcat(ACE1.scaling.(dB.basis.BB, 3)...))
+   solver = Dict("solver" => :rrqr, "rrqr_tol" => 1e-6, "P" => Γ)
+   IP_old, lsqinfo_old = lsqfit(dB, solver=solver, weights=weights, Vref=Vref, error_table = true)
+   IPFitting.add_fits!(IP_old, test)
+   rmse_table(lsqinfo_old["errors"])
+   rmse_table(test)
+
+   dB = LsqDB("", Bnew, train);
+   solver = Dict("solver" => :rrqr, "rrqr_tol" => 2e-6, "P" => Γ)
+   IP_new, lsqinfo_new = lsqfit(dB, solver=solver, weights=weights, Vref=Vref, error_table = true)
+   IPFitting.add_fits!(IP_new, test)
+   rmse_table(lsqinfo_new["errors"])
+   rmse_table(test)
+else
+   error("unknown transform")
+end 
+
+##
+
+@info("Training Error - Old Basis")
+rmse_table(lsqinfo_old["errors"])
+
+@info("Training Error - New Basis")
+rmse_table(lsqinfo_new["errors"])
+
+##
+
+@info("Test Error - Old Basis")
+IPFitting.add_fits!(IP_old, test)
+rmse_table(test)
+
+@info("Test Error - New Basis")
+IPFitting.add_fits!(IP_new, test)
+rmse_table(test)
+
+##
+
+at_dimer(r, z1, z0) = Atoms(X = [ SVector(0.0,0.0,0.0), SVector(r, 0.0, 0.0)], 
+                            Z = [z0, z1], pbc = false, 
+                            cell = [r+1 0 0; 0 1 0; 0 0 1])
+
+function dimer_energy(IP, r, z1, z0)
+   at = at_dimer(r, z1, z0)
+   at1 = Atoms(X = [SVector(0.0,0.0,0.0),], Z = [z1, ], pbc = false, cell = [1.0 0 0; 0 1.0 0; 0 0 1.0]) 
+   at2 = Atoms(X = [SVector(0.0,0.0,0.0),], Z = [z0, ], pbc = false, cell = [1.0 0 0; 0 1.0 0; 0 0 1.0]) 
+   return JuLIP.energy(IP, at) - JuLIP.energy(IP, at1) - JuLIP.energy(IP, at2)
+end
+
+zAl = AtomicNumber(:Al)
+zTi = AtomicNumber(:Ti)
+rr = range(0.1, rcut, length=200)
+
+plt = plot(; ylims = [-4, 4])
+plot!(plt, rr, dimer_energy.(Ref(IP_old), rr, zAl, zAl), lw=2, c=1, ls=:dash, label = "AlAl-old")
+plot!(plt, rr, dimer_energy.(Ref(IP_new), rr, zAl, zAl), lw=2, c=1, ls=:solid, label = "AlAl-new")
+plot!(plt, rr, dimer_energy.(Ref(IP_old), rr, zAl, zTi), lw=2, c=2, ls=:dash, label =  "AlTi-old")
+plot!(plt, rr, dimer_energy.(Ref(IP_new), rr, zAl, zTi), lw=2, c=2, ls=:solid, label = "AlTi-new")
+plot!(plt, rr, dimer_energy.(Ref(IP_old), rr, zTi, zTi), lw=2, c=3, ls=:dash, label =  "TiTi-old")
+plot!(plt, rr, dimer_energy.(Ref(IP_new), rr, zTi, zTi), lw=2, c=3, ls=:solid, label = "TiTi-new")
+vline!(plt, [rnn(:Ti), rnn(:Al)], c=:black, lw=2, label = "rnn")
+
+
+##
+
+# solver = Dict("solver" => :rrqr, "rrqr_tol" => 3e-6, "P" => Γ)
+
+using JuLIP: evaluate 
+using IPFitting: Dat 
+zbl = JuLIP.ZBLPotential()
+
+function dat_dimer(r, z1, z0) 
+   at = at_dimer(r, z1, z0)
+   E = ACE1.evaluate(envelope, r)
+   # zbl(r, z1, z0) 
+   # + Vref.E0[chemical_symbol(z1)] + Vref.E0[chemical_symbol(z0)]
+   return Dat(at, "dimer", E = E)
+end
+
+B_ = Bnew
+
+dB = LsqDB("", B_, train);
+A, y = IPFitting.Lsq.get_lsq_system(dB; Vref=Vref, weights=weights)
+
+r1 = 2.2
+w_core = 1e-2
+r_core = range(0.1, r1, length=100)
+A_core = zeros(3*length(r_core), length(B_))
+y_core = zeros(3*length(r_core))
+for (i, (r, (z1, z0))) in enumerate(Iterators.product(r_core, 
+                                        [(zAl, zAl), (zAl, zTi), (zTi, zTi)]))
+   dat = dat_dimer(r, z1, z0)
+   w = (r - r1) + (r-r1)^3
+   A_core[i, :] = w_core * w * energy(B_, dat.at)
+   y_core[i] = w_core * w * dat.D["E"][1]
+end
+
+A1 = [A; A_core]
+y1 = [y; y_core] 
+
+A2 = A1 / Γ
+y2 = y1 
+
+using LowRankApprox
+
+F = pqrfact(A2, rtol = 3e-6)
+θ_til = F \ y2 
+θ = Γ \ θ_til
+IP = ACE1.combine(B_, θ)
+
+@info("Test Error")
+IPFitting.add_fits!(IP, test)
+rmse_table(test)
+
+
+##
+
+zAl = AtomicNumber(:Al)
+zTi = AtomicNumber(:Ti)
+rr = range(0.1, rcut, length=200)
+
+plt = plot(; ylims = [-10, 10], xlims = [0.0, 5.5])
+# plot!(plt, rr, dimer_energy.(Ref(IP_old), rr, zAl, zAl), lw=2, c=1, ls=:dash, label = "AlAl-old")
+plot!(plt, rr, dimer_energy.(Ref(IP), rr, zAl, zAl), lw=2, c=1, ls=:solid, label = "AlAl-new")
+# plot!(plt, rr, dimer_energy.(Ref(IP_old), rr, zAl, zTi), lw=2, c=2, ls=:dash, label =  "AlTi-old")
+plot!(plt, rr, dimer_energy.(Ref(IP), rr, zAl, zTi), lw=2, c=2, ls=:solid, label = "AlTi-new")
+# plot!(plt, rr, dimer_energy.(Ref(IP_old), rr, zTi, zTi), lw=2, c=3, ls=:dash, label =  "TiTi-old")
+plot!(plt, rr, dimer_energy.(Ref(IP), rr, zTi, zTi), lw=2, c=3, ls=:solid, label = "TiTi-new")
+vline!(plt, [rnn(:Ti), rnn(:Al)], c=:black, lw=2, label = "rnn")
+
+# plot!(rr, zbl.(rr, zAl, zAl))
+# plot!(rr, evaluate.(Ref(envelope), rr))
+
+function get_rdf(data, rcut)
+   rdf = Dict((zAl, zAl) => Float64[], 
+              (zAl, zTi) => Float64[], 
+              (zTi, zAl) => Float64[], 
+              (zTi, zTi) => Float64[])
+   for dat in data 
+      at = dat.at 
+      nlist = neighbourlist(at, rcut)
+      for (i, j, rr) in NeighbourLists.pairs(nlist)
+         zi = at.Z[i]
+         zj = at.Z[j]
+         push!(rdf[(zi, zj)], sqrt(sum(rr.^2)))
+      end
+   end
+   return rdf 
+end
+
+rdf = get_rdf(data, 5.5)
+
+h1 = histogram(rdf[(zAl, zAl)], nbins=100, c=1, label = "rdf(Al, Al)", xlims = [0.0, 5.5])
+h2 = histogram(rdf[(zAl, zTi)], nbins=100, c=2, label = "rdf(Al, Ti)", xlims = [0.0, 5.5])
+h3 = histogram(rdf[(zTi, zTi)], nbins=100, c=3, label = "rdf(Ti, Ti)", xlims = [0.0, 5.5])
+
+plot(plt, h1, h2, h3, 
+     layout = Plots.GridLayout(4,1, heights=[0.7, 0.1, 0.1, 0.1]), 
+     size = (600, 800))
+
+
+## 
+
+using PyCall
+ARD = pyimport("sklearn.linear_model")["ARDRegression"]
+ard_threshold_lambda = 10_000 
+ard_tol = 1e-4
+fit_intercept=true
+ard_n_iter = 1000 
+
+clf = ARD(n_iter=ard_n_iter, threshold_lambda = ard_threshold_lambda, tol=ard_tol, fit_intercept=fit_intercept, normalize=true, compute_score=true)
+clf.fit(A2, y2)
+c = Γ \ clf.coef_
+IP_ard = ACE1.combine(B_, c)
+
+
+##
+
+zAl = AtomicNumber(:Al)
+zTi = AtomicNumber(:Ti)
+rr = range(0.1, rcut, length=200)
+
+plt = plot(; ylims = [-10, 10], xlims = [0.0, 5.5])
+# plot!(plt, rr, dimer.(Ref(IP_old), rr, zAl, zAl), lw=2, c=1, ls=:dash, label = "AlAl-old")
+plot!(plt, rr, dimer.(Ref(IP_ard), rr, zAl, zAl), lw=2, c=1, ls=:solid, label = "AlAl-new")
+# plot!(plt, rr, dimer.(Ref(IP_old), rr, zAl, zTi), lw=2, c=2, ls=:dash, label =  "AlTi-old")
+plot!(plt, rr, dimer.(Ref(IP_ard), rr, zAl, zTi), lw=2, c=2, ls=:solid, label = "AlTi-new")
+# plot!(plt, rr, dimer.(Ref(IP_old), rr, zTi, zTi), lw=2, c=3, ls=:dash, label =  "TiTi-old")
+plot!(plt, rr, dimer.(Ref(IP_ard), rr, zTi, zTi), lw=2, c=3, ls=:solid, label = "TiTi-new")
+vline!(plt, [rnn(:Ti), rnn(:Al)], c=:black, lw=2, label = "rnn")
+
+rdf = get_rdf(data, 5.5)
+h1 = histogram(rdf[(zAl, zAl)], nbins=100, c=1, label = "rdf(Al, Al)", xlims = [0.0, 5.5])
+h2 = histogram(rdf[(zAl, zTi)], nbins=100, c=2, label = "rdf(Al, Ti)", xlims = [0.0, 5.5])
+h3 = histogram(rdf[(zTi, zTi)], nbins=100, c=3, label = "rdf(Ti, Ti)", xlims = [0.0, 5.5])
+
+plot(plt, h1, h2, h3, 
+     layout = Plots.GridLayout(4,1, heights=[0.7, 0.1, 0.1, 0.1]), 
+     size = (600, 800))
+
+
+## 
+
+Bpair = Bpair_new
+Γpair = Diagonal(ACE1.scaling(Bpair, 3))
+
+dB = LsqDB("", Bpair, train);
+A, y = IPFitting.Lsq.get_lsq_system(dB; Vref=Vref, weights=weights)
+
+r1 = 3.0
+w_core = 1.0
+r_core = range(0.1, r1, length=100)
+A_core = zeros(3*length(r_core), length(Bpair))
+y_core = zeros(3*length(r_core))
+for (i, (r, (z1, z0))) in enumerate(Iterators.product(r_core, 
+                                        [(zAl, zAl), (zAl, zTi), (zTi, zTi)]))
+   dat = dat_dimer(r, z1, z0)
+   w = (r - r1)^2
+   A_core[i, :] = w_core * w * energy(Bpair, dat.at)
+   y_core[i] = w_core * w * dat.D["E"][1]
+end
+
+A1 = [A; A_core]
+y1 = [y; y_core] 
+
+A2 = A1 / Γpair
+y2 = y1 
+
+using LowRankApprox
+
+F = pqrfact(A2, rtol = 3e-6)
+θ_til = F \ y2 
+θ = Γpair \ θ_til
+IP = ACE1.combine(Bpair, θ)
+
+##
+
+plt = plot(; ylims = [-10, 10], xlims = [0.0, 5.5])
+# plot!(plt, rr, dimer.(Ref(IP_old), rr, zAl, zAl), lw=2, c=1, ls=:dash, label = "AlAl-old")
+plot!(plt, rr, dimer.(Ref(IP), rr, zAl, zAl), lw=2, c=1, ls=:solid, label = "AlAl-new")
+# plot!(plt, rr, dimer.(Ref(IP_old), rr, zAl, zTi), lw=2, c=2, ls=:dash, label =  "AlTi-old")
+plot!(plt, rr, dimer.(Ref(IP), rr, zAl, zTi), lw=2, c=2, ls=:solid, label = "AlTi-new")
+# plot!(plt, rr, dimer.(Ref(IP_old), rr, zTi, zTi), lw=2, c=3, ls=:dash, label =  "TiTi-old")
+plot!(plt, rr, dimer.(Ref(IP), rr, zTi, zTi), lw=2, c=3, ls=:solid, label = "TiTi-new")
+vline!(plt, [rnn(:Ti), rnn(:Al)], c=:black, lw=2, label = "rnn")

--- a/src/polynomials/orthpolys.jl
+++ b/src/polynomials/orthpolys.jl
@@ -22,7 +22,7 @@ using ACE1.Transforms: DistanceTransform, transform, transform_d,
 
 import Base: ==
 
-export transformed_jacobi
+export transformed_jacobi, transformed_jacobi_env, PolyEnvelope
 
 # this is a hack to prevent a weird compiler error that I don't understand
 # at all yet
@@ -190,7 +190,7 @@ function evaluate!(P, tmp, J::OrthPolyBasis, t; maxn=length(J))
    return P
 end
 
-function evaluate_d!(P, dP, tmp, J::OrthPolyBasis, t; maxn=length(J))
+function evaluate_ed!(P, dP, tmp, J::OrthPolyBasis, t; maxn=length(J))
    @assert maxn <= min(length(P), length(dP))
 
    P[1] = J.A[1] * _fcut_(J.pl, J.tl, J.pr, J.tr, t)
@@ -207,8 +207,11 @@ function evaluate_d!(P, dP, tmp, J::OrthPolyBasis, t; maxn=length(J))
       P[n] = α * P[n-1] + J.C[n] * P[n-2]
       dP[n] = α * dP[n-1] + J.C[n] * dP[n-2] + J.A[n] * P[n-1]
    end
-   return dP
+   return P, dP
 end
+
+evaluate_d!(P, dP, tmp, J::OrthPolyBasis, t; maxn=length(J)) = 
+         evaluate_ed!(P, dP, tmp, J, t, maxn)[2]
 
 """
 `discrete_jacobi(N; pcut=0, tcut=1.0, pin=0, tin=-1.0, Nquad = 1000)`
@@ -227,21 +230,22 @@ end
 #   Transformed Polynomials Basis
 # ----------------------------------------------------------------
 
-
-struct TransformedPolys{T, TT, TJ} <: ACE1.ScalarBasis{T}
+struct TransformedPolys{T, TT, TJ, TENV} <: ACE1.ScalarBasis{T}
    J::TJ          # the actual basis
    trans::TT      # coordinate transform
    rl::T          # lower bound r
    ru::T          # upper bound r = rcut
+   envelope::TENV
 end
 
 ==(J1::TransformedPolys, J2::TransformedPolys) = (
    (J1.J == J2.J) &&
    (J1.trans == J2.trans) &&
    (J1.rl == J2.rl) &&
-   (J1.ru == J2.ru) )
+   (J1.ru == J2.ru) && 
+   (J1.envelope == J2.envelope) )
 
-function TransformedPolys(J, trans, rl, ru)
+function TransformedPolys(J, trans, rl, ru, env = OneEnvelope())
    # get the combined type if rl, ru are different 
    T = promote_type(typeof(rl), typeof(ru))
    # integer is not allowed and we then default to float64 
@@ -250,7 +254,7 @@ function TransformedPolys(J, trans, rl, ru)
    end 
    rl_ = convert(T, rl) 
    ru_ = convert(T, ru)
-   return TransformedPolys(J, trans, rl_, ru_)
+   return TransformedPolys(J, trans, rl_, ru_, env)
 end
 
 write_dict(J::TransformedPolys) = Dict(
@@ -258,7 +262,8 @@ write_dict(J::TransformedPolys) = Dict(
       "J" => write_dict(J.J),
       "rl" => J.rl,
       "ru" => J.ru,
-      "trans" => write_dict(J.trans)
+      "trans" => write_dict(J.trans), 
+      "envelope" => write_dict(J.envelope),
    )
 
 TransformedPolys(D::Dict) =
@@ -266,7 +271,8 @@ TransformedPolys(D::Dict) =
       read_dict(D["J"]),
       read_dict(D["trans"]),
       D["rl"],
-      D["ru"]
+      D["ru"],
+      read_dict(D["envelope"]), 
    )
 
 read_dict(::Val{:ACE1_TransformedPolys}, D::Dict) = TransformedPolys(D)
@@ -292,6 +298,8 @@ function evaluate!(P, tmp, J::TransformedPolys, r, args...; maxn=length(J))
    t = transform(J.trans, r, args...)
    # evaluate the actual polynomials
    evaluate!(P, nothing, J.J, t; maxn=maxn)
+   e = evaluate(J.envelope, r)
+   @. P *= e
    return P
 end
 
@@ -300,8 +308,10 @@ function evaluate_d!(P, dP, tmp, J::TransformedPolys, r, args...; maxn=length(J)
    t = transform(J.trans, r, args...)
    dt = transform_d(J.trans, r, args...)
    # evaluate the actual Jacobi polynomials + derivatives w.r.t. x
-   evaluate_d!(P, dP, nothing, J.J, t, maxn=maxn)
-   @. dP *= dt
+   evaluate_ed!(P, dP, nothing, J.J, t, maxn=maxn)
+   e = evaluate(J.envelope, r)
+   de = evaluate_d(J.envelope, r)
+   @. dP = de * P + e * dP
    return dP
 end
 
@@ -350,6 +360,58 @@ function transformed_jacobi(maxdeg::Integer,
    return TransformedPolys(J, trans, rin, rcut)
 end
 
+
+
+# -------------------- Envelopes 
+
+import ACE1: evaluate, evaluate_d
+import ForwardDiff
+
+abstract type AbstractEnvelope end 
+
+evaluate_d(env::AbstractEnvelope, r::Real) = 
+      ForwardDiff.derivative( r1 -> evaluate(env, r1), r )
+
+struct OneEnvelope <: AbstractEnvelope 
+end
+
+evaluate(env::OneEnvelope, r::T) where {T <: Real} = one(T)
+
+
+struct PolyEnvelope{T} <: AbstractEnvelope 
+   p::Int
+   r0::T 
+   rcut::T
+end
+
+function evaluate(env::PolyEnvelope, r::T) where {T <: Real}
+   p, r0, rcut = env.p, env.r0, env.rcut
+   s = r/r0; scut = rcut/r0 
+   return s^(-p) - scut^(-p) + p * scut^(-p-1) * (s - scut)
+end
+
+# -------------------- utility function to construct radial basis with envelope 
+
+
+"""
+`transformed_jacobi_env(maxdeg, trans, envelope, rcut, rin)`
+
+This creates a radial basis where the cutoff mechanism is provided by the 
+envelope in the r domain. The orthogonality relation of the basis does not 
+include the envelope which can therefore be interpreted as a prior. 
+"""
+function transformed_jacobi_env(maxdeg::Integer,
+                                trans::DistanceTransform,
+                                envelope::AbstractEnvelope, 
+                                rcut::Real, rin::Real = 0.0;
+                                kwargs...)
+   J =  discrete_jacobi(maxdeg; 
+            tcut = transform(trans, rcut),
+            tin = transform(trans, rin),
+            pcut = 0,
+            kwargs...)
+   return TransformedPolys(J, trans, rin, rcut, envelope)
+end
 
 
 end

--- a/src/polynomials/transforms.jl
+++ b/src/polynomials/transforms.jl
@@ -53,13 +53,14 @@ struct PolyTransform{TP, T} <: DistanceTransform
    a::T 
 end
 
+PolyTransform(p, r0) = PolyTransform(p, r0, one(eltype(r0)))
 PolyTransform(; p = 2, r0 = 2.5, a = 1.0) = PolyTransform(p, r0, a)
 
 write_dict(T::PolyTransform) =
    Dict("__id__" => "ACE1_PolyTransform", 
              "p" => T.p, 
             "r0" => T.r0, 
-          "a" => T.a)
+             "a" => T.a)
 
 PolyTransform(D::Dict) = PolyTransform(D["p"], D["r0"], D["a"])
 

--- a/src/polynomials/transforms.jl
+++ b/src/polynomials/transforms.jl
@@ -25,46 +25,51 @@ inv_transform(t::DistanceTransform, x::Number, z::AtomicNumber, z0::AtomicNumber
 
 
 
-poly_trans(p, r0, r) = @fastmath(((1+r0)/(1+r))^p)
+poly_trans(p, r0, a, r) = 
+         @fastmath(((a+r0)/(a+r))^p)
 
-poly_trans_d(p, r0, r) = @fastmath((-p/(1+r0)) * ((1+r0)/(1+r))^(p+1))
+poly_trans_d(p, r0, a, r) = 
+         @fastmath((-p/(a+r0)) * ((a+r0)/(a+r))^(p+1))
 
-poly_trans_inv(p, r0, x) = ( (1+r0)/(x^(1/p)) - 1 )
+poly_trans_inv(p, r0, a, x) = 
+         ( (a+r0)/(x^(1/p)) - a )
 
-
-# TODO: generalise the distance transform to allow
-#       ((a + r0) / (a + r) )^p
 
 @doc raw"""
 Implements the distance transform
 ```math
-   x(r) = \Big(\frac{1 + r_0}{1 + r}\Big)^p
+   x(r) = \Big(\frac{\varepsilon + r_0}{\varepsilon + r}\Big)^p
 ```
 
 Constructor:
 ```
-PolyTransform(p, r0)
+PolyTransform(; p = 2, r0 = 2.5, a = 1.0)
+PolyTransform(p, r0, a)
 ```
 """
 struct PolyTransform{TP, T} <: DistanceTransform
    p::TP
    r0::T
+   a::T 
 end
 
-PolyTransform(; p = 2, r0 = 2.5) = PolyTransform(p, r0)
+PolyTransform(; p = 2, r0 = 2.5, a = 1.0) = PolyTransform(p, r0, a)
 
 write_dict(T::PolyTransform) =
-   Dict("__id__" => "ACE1_PolyTransform", "p" => T.p, "r0" => T.r0)
+   Dict("__id__" => "ACE1_PolyTransform", 
+             "p" => T.p, 
+            "r0" => T.r0, 
+          "a" => T.a)
 
-PolyTransform(D::Dict) = PolyTransform(D["p"], D["r0"])
+PolyTransform(D::Dict) = PolyTransform(D["p"], D["r0"], D["a"])
 
 read_dict(::Val{:ACE1_PolyTransform}, D::Dict) = PolyTransform(D)
 
-transform(t::PolyTransform, r::Number) = poly_trans(t.p, t.r0, r)
+transform(t::PolyTransform, r::Number) = poly_trans(t.p, t.r0, t.a, r)
 
-transform_d(t::PolyTransform, r::Number) = poly_trans_d(t.p, t.r0, r)
+transform_d(t::PolyTransform, r::Number) = poly_trans_d(t.p, t.r0, t.a, r)
 
-inv_transform(t::PolyTransform, x::Number) = poly_trans_inv(t.p, t.r0, x)
+inv_transform(t::PolyTransform, x::Number) = poly_trans_inv(t.p, t.r0, t.a, x)
 
 (t::PolyTransform)(x) = transform(t, x)
 

--- a/test/polynomials/test_orthpolys.jl
+++ b/test/polynomials/test_orthpolys.jl
@@ -6,8 +6,6 @@
 # --------------------------------------------------------------------------
 
 
-@testset "OrthogonalPolynomials" begin
-
 @info("--------- Testing OrthogonalPolynomials ----------")
 
 ##
@@ -83,6 +81,7 @@ Pnew = ACE1.OrthPolys.transformed_jacobi(10, trans, 2.0, 0.5; pcut = 2, pin = 2)
 
 @info("   ... consistency of derivatives")
 for ntest = 1:30
+   local r 
    r = 2*rand() + 0.25
    dp = evaluate_d(Pnew, r)
    if r <= 0.5 || r >= 2.0
@@ -129,7 +128,6 @@ println()
 
 ##
 
-end
 
 # ## Quick look at the basis
 # using Plots

--- a/test/polynomials/test_rylm.jl
+++ b/test/polynomials/test_rylm.jl
@@ -6,7 +6,6 @@
 # --------------------------------------------------------------------------
 
 
-@testset "Real  Ylm" begin
 
 ##
 import ACE1
@@ -64,6 +63,7 @@ for nsamples = 1:30
    errs = []
    verbose && @printf("     h    | error \n")
    for p = 2:10
+      local h 
       h = 0.1^p
       DYh = similar(DY)
       Rh = Vector(R)
@@ -80,5 +80,3 @@ for nsamples = 1:30
 end
 println()
 
-
-end

--- a/test/polynomials/test_transforms.jl
+++ b/test/polynomials/test_transforms.jl
@@ -6,9 +6,6 @@
 # --------------------------------------------------------------------------
 
 
-
-@testset "Transforms" begin
-
 ##
 using ACE1, Printf, Test, LinearAlgebra, JuLIP, JuLIP.Testing
 using JuLIP: evaluate, evaluate_d
@@ -19,6 +16,7 @@ maxdeg = 10
 
 @info("Testing Transforms and TransformedPolys")
 for p in 2:4
+   local h, trans 
    @info("p = $p, random transform")
    trans = PolyTransform(1+rand(), 1+rand())
    @info("      test (de-)dictionisation")
@@ -52,6 +50,7 @@ for p = 2:4
    trans = PolyTransform(p, r0)
    ACE1.Testing.test_transform(trans, [r0/2, 3*r0])
 end
+println()
 
 ##
 @info("Testing Morse Transform")
@@ -60,6 +59,7 @@ for lam = 1.0:3.0
    trans = ACE1.Transforms.MorseTransform(lam, r0)
    ACE1.Testing.test_transform(trans, [r0/2, 3*r0])
 end
+println()
 
 ##
 
@@ -69,6 +69,7 @@ for p = 2:4
    trans = ACE1.Transforms.AgnesiTransform(r0, p)
    ACE1.Testing.test_transform(trans, [r0/2, 3*r0])
 end
+println()
 
 ##
 
@@ -159,4 +160,3 @@ println_slim(@test all(JuLIP.Testing.test_fio(trans)))
 
 ##
 
-end

--- a/test/polynomials/test_ylm.jl
+++ b/test/polynomials/test_ylm.jl
@@ -6,8 +6,6 @@
 # --------------------------------------------------------------------------
 
 
-@testset "Ylm" begin
-
 ##
 import ACE1
 using JuLIP.Testing
@@ -45,6 +43,7 @@ end
 @info("Test: check complex spherical harmonics against explicit expressions")
 nsamples = 30
 for n = 1:nsamples
+   local r
    θ = rand() * π
    φ = (rand()-0.5) * 2*π
    r = 0.1+rand()
@@ -60,6 +59,7 @@ println()
 @info("      ... same near pole")
 nsamples = 30
 for n = 1:nsamples
+   local r 
    θ = rand() * 1e-9
    if θ < 1e-10
       θ = 0.0
@@ -78,6 +78,7 @@ println()
 verbose=false
 @info("Test: check derivatives of associated legendre polynomials")
 for nsamples = 1:30
+   local h 
    θ = 0.1+0.4 * pi * rand()
    L = 5
    P = ACE1.SphericalHarmonics.compute_p(L, θ)
@@ -109,6 +110,7 @@ println()
 
 @info("      ... same near pole")
 for nsamples = 1:30
+   local h 
    θ = rand() * 1e-8
    L = 5
    P = ACE1.SphericalHarmonics.compute_p(L, θ)
@@ -146,11 +148,12 @@ println(@test(spher2cart(s) == r))
 
 @info("Very large numbers")
 for ntest = 1:20
+   local s 
    rr = 1e130 * rand(SVector{3, Float64})
    s = cart2spher(rr)
    print_tf(@test(abs(s.cosθ) <= 1))
 end
-
+println() 
 
 ##
 
@@ -174,6 +177,7 @@ println()
 
 @info("Test: check derivatives of complex spherical harmonics")
 for nsamples = 1:30
+   local h 
    R = @SVector rand(3)
    SH = SHBasis(5)
    Y, dY = evaluate_ed(SH, R)
@@ -216,5 +220,3 @@ println()
 # end
 
 ##
-
-end # @testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@
 # Licensed under ASL - see ASL.md for terms and conditions.
 # --------------------------------------------------------------------------
 
-
+##
 using ACE1, Test, Printf, LinearAlgebra, StaticArrays, BenchmarkTools,
       JuLIP, JuLIP.Testing
 
@@ -13,14 +13,14 @@ using ACE1, Test, Printf, LinearAlgebra, StaticArrays, BenchmarkTools,
 @testset "ACE1.jl" begin
     # ------------------------------------------
     #   basic polynomial basis building blocks
-    include("polynomials/test_ylm.jl")
-    include("polynomials/test_rylm.jl")
-    include("polynomials/test_transforms.jl")
-    include("polynomials/test_orthpolys.jl")
+    @testset "Ylm" begin include("polynomials/test_ylm.jl") end 
+    @testset "Real  Ylm" begin include("polynomials/test_rylm.jl") end 
+    @testset "Transforms" begin include("polynomials/test_transforms.jl") end 
+    @testset "OrthogonalPolynomials" begin include("polynomials/test_orthpolys.jl") end 
 
     # --------------------------------------------
     # core permutation-invariant functionality
-    include("test_1pbasis.jl")
+    @testset "1-Particle Basis"  begin include("test_1pbasis.jl") end 
     include("test_pibasis.jl")
     include("test_pipot.jl")
 

--- a/test/test_1pbasis.jl
+++ b/test/test_1pbasis.jl
@@ -5,9 +5,6 @@
 # Licensed under ASL - see ASL.md for terms and conditions.
 # --------------------------------------------------------------------------
 
-
-@testset "1-Particle Basis"  begin
-
 ##
 
 using ACE1, ACE1.Testing 
@@ -34,6 +31,7 @@ evaluate_d(P1, Rs[1], Zs[1], z0)
 ##
 
 for species in (:X, :Si, [:C, :O, :H])
+   local Nat, P1, Rs, Zs, z0, h 
    @info("species = $species")
    Nat = 15
    P1 = ACE1.BasicPSH1pBasis(Pr; species = species)
@@ -80,5 +78,3 @@ end
 
 
 ##
-
-end


### PR DESCRIPTION
This implements a variation of the radial basis where
- more general envelopes are allowed 
- the orthogonality relation does not incorporate the envelope functions
This is based on @WillBaldwin0 's observations that our previous regularization can lead to really bad dimers. This radial basis appears to give a better smoothness prior that doesn't lead to similar oscillations. It is an alternative to Will's own solution - we have not compared yet.

To see it in action on a toy regression problem see `examples/newreg.jl`

CC @casv2 