### PR TITLE
Committee for OneBody

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -22,7 +22,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Combinatorics = "1"
 ForwardDiff = "0.10"
-JuLIP = "= 0.11.0, 0.11.3"
+JuLIP = "0.11.3"
 NeighbourLists = "0.5.1 - 0"
 StaticArrays = "1.5"
 julia = "1.6, 1.7"

--- a/src/committee.jl
+++ b/src/committee.jl
@@ -536,3 +536,33 @@ function co_virial(V::SumIP, at::AbstractAtoms; kwargs...)
    vv = [ co_virial(calc, at; kwargs...) for calc in V.components ]
    return sum( v[1] for v in vv ), sum( v[2] for v in vv )
 end
+
+
+# ------------------------------------------------------------
+#    One Body Committee 
+
+using JuLIP: OneBody
+
+struct FlexConstTensor{T} 
+   v::T 
+end
+
+import Base: +
+
++(a::FlexConstTensor, b::AbstractArray) = b .+ Ref(a.v)
++(b::AbstractArray, a::FlexConstTensor) = b .+ Ref(a.c)
+
+function co_energy(V::OneBody, at::AbstractAtoms; kwargs...)
+   E = energy(V, at) 
+   return E, FlexConstTensor(E)
+end
+
+function co_forces(V::OneBody, at::AbstractAtoms; kwargs...)
+   F = forces(V, at)
+   return F, FlexConstTensor(F)
+end
+
+function co_virial(V::OneBody, at::AbstractAtoms; kwargs...)
+   vir = virial(V, at)
+   return vir, FlexConstTensor(vir)
+end

--- a/test/pair/test_pair_basis.jl
+++ b/test/pair/test_pair_basis.jl
@@ -56,6 +56,7 @@ println(@test all(JuLIP.Testing.test_fio(pB)))
 
 @info("Finite-difference test on PolyPairBasis forces")
 for ntest = 1:30
+   local E, h, V, coeffs 
    E = energy(pB, at)
    DE = - forces(pB, at)
    U = [ (rand(JVecF) .- 0.5) for _=1:length(at) ]

--- a/test/polynomials/test_multitrans.jl
+++ b/test/polynomials/test_multitrans.jl
@@ -56,7 +56,7 @@ trans = multitransform(transforms, rin = rin, rcut = rcut)
 
 xmin = 1e30; xmax = - 1e30 
 for ntest = 1:100
-   local r, z0 
+   local r, z0, z
    r = rin + rand() * (rcut - rin)
    z, z0 = (rand([zFe, zC, zAl], 2)...,)
    x = transform(trans, r, z, z0)
@@ -88,7 +88,7 @@ trans2 = multitransform(transforms, cutoffs=cutoffs)
 
 xmin = 1e30; xmax = - 1e30 
 for ntest = 1:100
-   local rin, rcut , z0, s, r 
+   local rin, rcut , z0, s, r, z 
    z, z0 = (rand([zFe, zC, zAl], 2)...,)
    s, s0 = chemical_symbol.((z, z0))
    rin, rcut = try 
@@ -154,7 +154,7 @@ println_slim(@test (try
 
 @info("some random finite-difference tests")
 for ntest = 1:30 
-   local r, z0 
+   local r, z0, z, F  
    r = 2 + rand() 
    z, z0 = (rand([zFe, zC, zAl], 2)...,)
    P = evaluate(B, r, z, z0)

--- a/test/test_committee_pair.jl
+++ b/test/test_committee_pair.jl
@@ -144,3 +144,29 @@ vir1 = virial(V_comb, at)
 vir2, co_vir = ACE1.co_virial(co_V_comb, at)
 println_slim(@test (vir1 ≈ vir2 ≈ mean(co_vir)))
 println_slim(@test co_vir ≈ ACE1.co_virial(co_V, at)[2] + ACE1.co_virial(co_Vace, at)[2])
+
+
+## 
+
+@info("check OneBody committee behaviour") 
+
+V1 = JuLIP.OneBody(:W => randn())
+co_V_comb1 = JuLIP.MLIPs.SumIP(V1, co_Vace, co_V)
+
+@info("    ... energy")
+E1, co_E1 = ACE1.co_energy(co_V_comb, at)
+E2, co_E2 = ACE1.co_energy(co_V_comb1, at)
+println_slim(@test E2 ≈ E1 + energy(V1, at))
+println_slim(@test co_E1 .+ energy(V1, at) ≈ co_E2)
+
+@info("    ... forces")
+F1, co_F1 = ACE1.co_forces(co_V_comb, at)
+F2, co_F2 = ACE1.co_forces(co_V_comb1, at)
+println_slim(@test F2 ≈ F1)
+println_slim(@test co_F1 ≈ co_F2)
+
+@info("    ... virials")
+vir1, co_vir1 = ACE1.co_virial(co_V_comb, at)
+vir2, co_vir2 = ACE1.co_virial(co_V_comb1, at)
+println_slim(@test vir2 ≈ vir1)
+println_slim(@test co_vir1 ≈ co_vir2)


### PR DESCRIPTION
@casv2  --- this PR implements `co_energy`, `co_forces` and `co_virial` for the `OneBody` potential type. The behaviour is simply that all committee members evaluate the same value as the potential itself. My thought was that because it is a reference potential we don't - at the moment - need a proper committe and this was easy to provide. Do you agree with that? Then I'll merge and tag a new version. 

If at a later date we want a proper one-body committe then we can provide that. 