### PR TITLE
WIP: Performance of committee kernels 

### DIFF
--- a/profile/profile_committees.jl
+++ b/profile/profile_committees.jl
@@ -1,0 +1,92 @@
+
+using ACE1, JuLIP, LinearAlgebra, Statistics, StaticArrays, BenchmarkTools, Base.Threads
+using JuLIP.MLIPs: combine 
+
+@show nthreads() 
+
+maxdeg = 18
+N = 3
+
+r0 = rnn(:Cu)
+rcut = 2.5 * r0 
+basis = ACE1.Utils.rpi_basis(; species=:Cu, N=N, r0=r0, maxdeg=maxdeg, rcut=rcut)
+@show len = length(basis) 
+NCO = 32
+co_c = Diagonal(1 ./ (1:len).^2) * randn(len, NCO)
+c = mean(co_c, dims=(2,))[:]
+
+V = combine(basis, c)
+co_V = ACE1.committee_potential(basis, c, co_c)
+Pr = V.pibasis.basis1p.J
+
+
+using JuLIP
+at = rattle!(bulk(:Cu, cubic=true) * 4, 0.2)
+@show length(at)
+
+##
+#warmup 
+energy(V, at)
+ACE1.co_energy(co_V, at)
+
+@info("Energy")
+print("Potential: "); @time energy(V, at)
+print("Committee: "); @time ACE1.co_energy(co_V, at)
+
+##
+#warmup 
+forces(V, at)
+ACE1.co_forces(co_V, at)
+
+@info("Forces")
+print("Potential: "); @time forces(V, at)
+print("Committee: "); @time ACE1.co_forces(co_V, at)
+
+## 
+
+# using Base.Threads
+# nt = nthreads()
+# NCO = ACE1.ncommittee(co_V)
+# T = ACE1.fltype(co_V)
+# tmp_d = [ ACE1.alloc_temp_d(co_V, at) for _ in 1:nt ]
+# F0 = zeros(JVec{T}, length(at))
+# F = [ copy(F0) for _ in 1:nt ]
+# co_F = [ SVector(ntuple(_ -> copy(F0), NCO)...) for _ in 1:nt ]
+
+# ACE1.co_forces!(F, co_F, tmp_d, co_V, at)
+
+# print("Committe!: "); @time ACE1.co_forces!(F, co_F, tmp_d, co_V, at)
+
+# ##
+
+# @profview let co_V = co_V, at=at 
+#    for _ = 1:40
+#       ACE1.co_forces(co_V, at)
+#    end
+# end
+
+# ##
+
+# @profview let F = F, co_F = co_F, tmp_d = tmp_d, co_V = co_V, at = at
+#    for _ = 1:30
+#       ACE1.co_forces!(F, co_F, tmp_d, co_V, at)
+#    end
+# end
+
+##
+
+virial(V, at)
+ACE1.co_virial(co_V, at)
+
+@info("Virial")
+print("Potential: "); @time virial(V, at)
+print("Committee: "); @time ACE1.co_virial(co_V, at)
+
+
+##
+
+# @profview let co_V = co_V, at = at
+#    for _ = 1:10
+#       ACE1.co_virial(co_V, at)
+#    end
+# end

--- a/src/pipot.jl
+++ b/src/pipot.jl
@@ -50,8 +50,7 @@ standardevaluator(V::PIPotential) =
 
 maxorder(V::PIPotential) = maxorder(V.pibasis)
 
-ncommittee(V::PIPotential{T, NZ, TPI, TEV, NCO}) where {T, NZ, TPI, TEV, NCO} = 
-   isnothing(V.committee) ? 0 : NCO 
+ncommittee(V::PIPotential{T, NZ, TPI, TEV, NCO}) where {T, NZ, TPI, TEV, NCO} = NCO 
 
 # ------------------------------------------------------------
 #   Initialisation code


### PR DESCRIPTION
This fixes a type-instability deep inside the commitee kernels 
```
BEFORE FIX 

(base) ortner@CosmicCrisp profile % j18 --project=.. -t 8 profile_committees.jl
nthreads() = 8
len = length(basis) = 1119
length(at) = 256
[ Info: Energy
Potential:   0.004407 seconds (240.58 k allocations: 7.521 MiB)
Committee:   0.095018 seconds (5.43 M allocations: 719.990 MiB, 45.24% gc time)
[ Info: Forces
Potential:   0.025057 seconds (677.80 k allocations: 21.844 MiB)
Committee:  29.404100 seconds (2.46 G allocations: 168.960 GiB, 48.25% gc time)
[ Info: Virial
Potential:   0.025030 seconds (677.78 k allocations: 21.749 MiB)
Committee:  29.351164 seconds (2.46 G allocations: 168.959 GiB, 48.24% gc time)



AFTER FIX

(base) ortner@CosmicCrisp profile % j18 --project=.. -t 8 profile_committees.jl
nthreads() = 8
len = length(basis) = 1119
length(at) = 256
[ Info: Energy
Potential:   0.004448 seconds (240.44 k allocations: 7.518 MiB)
Committee:   0.005977 seconds (240.46 k allocations: 7.517 MiB)
[ Info: Forces
Potential:   0.026286 seconds (677.43 k allocations: 21.834 MiB)
Committee:   0.153319 seconds (679.02 k allocations: 207.272 MiB, 43.56% gc time)
[ Info: Virial
Potential:   0.027093 seconds (677.41 k allocations: 21.739 MiB)
Committee:   0.092613 seconds (679.02 k allocations: 205.809 MiB, 10.13% gc ti
```

New results look better but TBH far from great. I know the source of the slow-down and thought I had a fix for it, but it does not yet work as expected.

Should this still be merged and tagged? 

CC @casv2 @wcwitt 