### PR TITLE
Remove Zeros from B

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ACE1"
 uuid = "e3f9bc04-086e-409a-ba78-e9769fe067bb"
-version = "v0.11.6-DEV"
+version = "v0.11.7-DEV"
 
 
 [deps]

--- a/src/rpi/rpi_basis.jl
+++ b/src/rpi/rpi_basis.jl
@@ -278,6 +278,35 @@ function scaling(basis::RPIBasis, p; a2b = abs2,
    return fin.(wwrpi)
 end
 
+"""
+when changing the coupling coefficients, it can happen that some basis 
+functions become identically zero. This function removes those 
+and then creates a new basis object which is returned. 
+"""
+function remove_zeros(basis::RPIBasis)
+   A2Bmaps = ()
+   Bz0inds = () 
+   need_new_basis = false
+   idx = 0 
+
+   for iz0 = 1:numz(basis)
+      CC = basis.A2Bmaps[iz0]
+      Inz = findall(!iszero, sum(abs, CC, dims=2)[:])
+      if length(Inz) < size(CC, 1)
+         need_new_basis = true
+      end
+      len = length(Inz)
+      A2Bmaps = (A2Bmaps..., CC[Inz, :])
+      Bz0inds = (Bz0inds..., idx+1:idx+len)
+      idx += len
+   end
+
+   if need_new_basis
+      return RPIBasis(basis.pibasis, A2Bmaps, Bz0inds)
+   else
+      return basis
+   end
+end
 
 # ------------------------------------------------------------------------
 #    Evaluation code


### PR DESCRIPTION
this PR implements an experimental prototype to remove zeros from the B basis.  (RPIBasis) A future PR should make this a default, combined with a general implementation of sparsification of the basis. 