### PR TITLE
Fix version bounds for Interpolations.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Combinatorics = "1"
 ForwardDiff = "0.10"
-Interpolations = "0.14"
+Interpolations = "0.14.7"
 JuLIP = "0.14.5"
 NeighbourLists = "0.5.1 - 0"
 Roots = "2"


### PR DESCRIPTION
Version bounds for Interpolations.jl are not correct, and it is possible to get a version that leaves ACE1 in broken state. This PR fixes that.

This seems to happen when ACE is used together with Molly that causes an old version of Interpolations.jl to load that does not have cubic splines convenience functions.

There is also new breaking version for Interpolations.jl that might be worth adding to allowed list. It however gives an error with splines. So, I excluded it here. To get this version, you need to allow it first in JuLIP, so none should be getting it atm.

I suggest just merging this and tagging a new version, and hopefully other users wont get the bug.

@cortner 